### PR TITLE
Modernize to Swift 6: language mode, Sendable, code cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -35,16 +35,6 @@ let package = Package(
             name: "LemmyKitTests",
             dependencies: ["LemmyKit"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )
-
-let swiftSettings: [SwiftSetting] = [
-    .enableExperimentalFeature("StrictConcurrency"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-]
-
-for target in package.targets {
-    var settings = target.swiftSettings ?? []
-    settings.append(contentsOf: swiftSettings)
-    target.swiftSettings = settings
-}

--- a/Sources/LemmyKit/LemmyApiError.swift
+++ b/Sources/LemmyKit/LemmyApiError.swift
@@ -6,7 +6,14 @@
 
 import Foundation
 
-public enum LemmyApiError: Error {
+/// Errors thrown by ``LemmyApi`` calls.
+///
+/// Marked `@unchecked Sendable` so callers can store an instance in
+/// `@Observable` view-model state. The carried `any Error` payloads are
+/// not themselves `Sendable`, but in practice callers pass them around
+/// as immutable terminal failure values; the conformance is a pragmatic
+/// concession to that usage.
+public enum LemmyApiError: Error, @unchecked Sendable {
     /// A network error has occurred.
     case network(Error)
 

--- a/Sources/LemmyKit/LemmyCredential.swift
+++ b/Sources/LemmyKit/LemmyCredential.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct LemmyCredential: Codable {
+public struct LemmyCredential: Codable, Sendable {
     let jwt: String
 
     public init(jwt: String) {

--- a/Sources/LemmyKit/Utils/CommunityFilter.swift
+++ b/Sources/LemmyKit/Utils/CommunityFilter.swift
@@ -6,21 +6,15 @@
 
 import Foundation
 
-public enum CommunityFilter {
+public enum CommunityFilter: Sendable {
     case id(Components.Schemas.CommunityID)
     case name(String)
 
     var id: Components.Schemas.CommunityID? {
-        if case let .id(communityID) = self {
-            return communityID
-        }
-        return nil
+        if case let .id(communityID) = self { communityID } else { nil }
     }
 
     var name: String? {
-        if case let .name(string) = self {
-            return string
-        }
-        return nil
+        if case let .name(string) = self { string } else { nil }
     }
 }

--- a/Sources/LemmyKit/Utils/Date+lemmyFormat.swift
+++ b/Sources/LemmyKit/Utils/Date+lemmyFormat.swift
@@ -8,10 +8,6 @@ import Foundation
 
 extension Date {
     init(lemmyFormat stringValue: String) throws {
-        guard #available(macOS 12.0, *) else {
-            fatalError()
-        }
-
         let utc = TimeZone(abbreviation: "UTC")!
 
         // Lemmy 0.19.0 format: 2024-06-09T11:54:37.981990Z

--- a/Sources/LemmyKit/Utils/LemmyDateTranscoder.swift
+++ b/Sources/LemmyKit/Utils/LemmyDateTranscoder.swift
@@ -8,11 +8,17 @@ import Foundation
 import OpenAPIRuntime
 
 struct LemmyDateTranscoder: DateTranscoder {
+    struct EncodingNotSupported: Error, CustomStringConvertible {
+        var description: String {
+            "LemmyDateTranscoder is decode-only — no Lemmy endpoint we use sends a Date in a request body."
+        }
+    }
+
     func decode(_ value: String) throws -> Date {
         try Date(lemmyFormat: value)
     }
 
-    func encode(_ value: Date) throws -> String {
-        fatalError("not implemented")
+    func encode(_: Date) throws -> String {
+        throw EncodingNotSupported()
     }
 }

--- a/Sources/LemmyKit/Utils/LenientUrl.swift
+++ b/Sources/LemmyKit/Utils/LenientUrl.swift
@@ -12,7 +12,7 @@ import Foundation
 /// about the url strings it parses. Not everything that is permitted in a browser url bar is permitted by ``URL``.
 ///
 /// LenientUrl attempts to decode raw string into URL as leniently as possible but does not fail if it fails.
-public struct LenientUrl: Decodable {
+public struct LenientUrl: Decodable, Sendable {
     /// The original raw string representation of the url.
     public let rawValue: String
 

--- a/Sources/LemmyKit/Utils/LikeStatus.swift
+++ b/Sources/LemmyKit/Utils/LikeStatus.swift
@@ -13,9 +13,9 @@ public enum LikeStatus: Int32, CustomStringConvertible, Sendable {
 
     public var description: String {
         switch self {
-        case .liked: return "liked"
-        case .disliked: return "disliked"
-        case .neutral: return "neutral"
+        case .liked: "liked"
+        case .disliked: "disliked"
+        case .neutral: "neutral"
         }
     }
 }


### PR DESCRIPTION
## Summary

Swift 6 modernization pass. Mirrors what just landed in DiasporaNodeInfo.

- **Swift 6 language mode.** `swift-tools-version` bumped to 6.0 and the package builds cleanly under `swiftLanguageModes: [.v6]`. The experimental `StrictConcurrency` and upcoming `DisableOutwardActorInference` settings are now implicit, so they're dropped. **This unblocks consumers (Spud) from needing `@preconcurrency import LemmyKit`** for the `LemmyApi` actor and value-type sends.
- **Sendable additions.** `LemmyApiError` is `@unchecked Sendable` (callers can store the error in `@Observable` view-model state; the carried `any Error` payloads aren't Sendable themselves, hence `@unchecked`). `CommunityFilter` and `LenientUrl` gain unconditional `Sendable`. `LikeStatus`, `Filter`, `CommentPath`, and the `AuthorizationMiddleware` actor were already Sendable.
- **`fatalError` → thrown error.** `LemmyDateTranscoder.encode` was a `fatalError(\"not implemented\")` — replaced with a thrown `EncodingNotSupported` error so a future endpoint that sends a `Date` in a request body fails the request rather than crashing the process.
- **Drop dead availability guard.** `Date(lemmyFormat:)` opened with `guard #available(macOS 12.0, *) else { fatalError() }` but the package's minimum macOS is 13. The branch was unreachable.
- **Style.** Drop redundant `return` keywords on single-line switch cases; fold `if-case` body to single-expression form in `CommunityFilter`.

## Test plan

- [x] `swift build` clean — 0 errors, 0 warnings under Swift 6 mode.
- [x] `swift test` — all 7 existing tests pass.

## Notes

- Min platforms unchanged (iOS 15 / macOS 13).
- No OpenAPI regen — current contract still works against live Lemmy servers per Spud's usage. Regen lives behind a separate trigger (an endpoint we use changing).
- The repetitive `switch response { case .ok ... case .unauthorized ... case .badRequest ... case .undocumented ... }` boilerplate across every `LemmyApi+*.swift` file is tempting to refactor into a shared helper, but each method's success-case payload type differs and the error mapping is identical — that's a separate, larger change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)